### PR TITLE
wget from raw.githubusercontent.com to avoid html stuff

### DIFF
--- a/book/preliminary/pcluster-login.ipynb
+++ b/book/preliminary/pcluster-login.ipynb
@@ -87,7 +87,7 @@
     "\n",
     "```\n",
     "# from your home directory on the p-cluster, download the example.bashrc \n",
-    "wget https://github.com/ECCO-Hackweek/ecco-2024/blob/main/assets/example.bashrc \n",
+    "wget https://raw.githubusercontent.com/ECCO-Hackweek/ecco-2024/refs/heads/main/assets/example.bashrc\n",
     "# rename it to .bashrc \n",
     "mv example.bashrc .bashrc \n",
     "```\n",
@@ -109,13 +109,21 @@
    "notebook_metadata_filter": "-all"
   },
   "kernelspec": {
-   "display_name": "Python 3.9.6 64-bit",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.9.6"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.7"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
wget https://raw.githubusercontent.com/ECCO-Hackweek/ecco-2024/refs/heads/main/assets/example.bashrc

instead of

wget https://github.com/ECCO-Hackweek/ecco-2024/blob/main/assets/example.bashrc