### PR TITLE
Added minor clarification to description

### DIFF
--- a/book/preliminary/oss_initial_repo.ipynb
+++ b/book/preliminary/oss_initial_repo.ipynb
@@ -90,7 +90,7 @@
     "\n",
     "## Add upstream remote (shared repository)\n",
     "\n",
-    "When you cloned the `ecco-2024` repository, you actually cloned the fork of the repo that you own, and that is designated for your code changes. So the local version of the repo is what you have on your machine (i.e., OSS), and the remote of this repo (called *origin*) is your fork on Github. You can check this by running ```git remote -v``` and you will see something like:\n",
+    "When you cloned the `ecco-2024` repository, you actually cloned the fork of the repo that you own, and that is designated for your code changes. So the local version of the repo is what you have on your machine (i.e., OSS), and the remote of this repo (called *origin*) is your fork on Github. You can check this by going to the repo directory `cd /home/jovyan/ecco-2024` and running ```git remote -v```. You will see something like:\n",
     "\n",
     "```\n",
     "origin  git@github.com:{username}/ecco-2024.git (fetch)\n",


### PR DESCRIPTION
In the final section "Add upstream remote (shared repository)", I added a few words to clarify that you need to `cd` into the remote repo directory before `git remote -v`. For github users, this is obvious but if this is new for some participants, it's probably helpful to add.