### PR TITLE
a bit more docs about Spack

### DIFF
--- a/book/tutorials/pcluster/example.bashrc
+++ b/book/tutorials/pcluster/example.bashrc
@@ -132,5 +132,5 @@ module load singularity-3.8.3-gcc-11.1.0-wqau5pb
 module load python-3.9.7-gcc-11.1.0-cacmhhm
 
 # add new path
-export PATH="$PATH:/home/owang/.local/bin:/efs_ecco/ECCO/EMU/emu_userinterface_dir"
+export PATH="$PATH:$HOME/.local/bin:/efs_ecco/ECCO/EMU/emu_userinterface_dir"
 

--- a/book/tutorials/pcluster/example.bashrc
+++ b/book/tutorials/pcluster/example.bashrc
@@ -132,5 +132,6 @@ module load singularity-3.8.3-gcc-11.1.0-wqau5pb
 module load python-3.9.7-gcc-11.1.0-cacmhhm
 
 # add new path
-export PATH="$PATH:$HOME/.local/bin:/efs_ecco/ECCO/EMU/emu_userinterface_dir"
+# export PATH="$PATH:$HOME/.local/bin:/efs_ecco/ECCO/EMU/emu_userinterface_dir"
+export PATH="$PATH:/home/owang/.local/bin:/efs_ecco/ECCO/EMU/emu_userinterface_dir"
 

--- a/book/tutorials/pcluster/pcluster-spack_and_slurm.ipynb
+++ b/book/tutorials/pcluster/pcluster-spack_and_slurm.ipynb
@@ -20,7 +20,16 @@
     "*Spack is a flexible package manager designed for building and managing multiple software versions in high-performance computing environments. It allows users to easily install software with different configurations, dependencies, and compilers without interference between installations. Spack supports reproducibility and portability, making it ideal for complex scientific workflows across different systems.* - ChatGPT\n",
     "\n",
     "### Setting up your environment for Spack\n",
-    "The [example .bashrc](./example.bashrc) initializes Spack profile. One can use Spack to install software and generate new modules even as a non-root user, although the collection of modules on the P-Cluster is already extensive.  \n",
+    "\n",
+    "One can use Spack to install software and generate new modules even as a non-root user, although the collection of modules on the P-Cluster is already extensive. \n",
+    "\n",
+    "- For the EMU application we recommend a more specific configutation -- [example .bashrc](./example.bashrc) initializes Spack profile.\n",
+    "- For tutorials that run `MITgcm` directly you can also reset Spack and add modules using [Julia_ECCO_and_more/setup_modules.csh](../tutorials/Julia_ECCO_and_more/setup_modules.csh).\n",
+    "- Or for a default initialization of Spack, you can just run the following command.\n",
+    "\n",
+    "```\n",
+    "source /shared/spack/share/spack/setup-env.sh\n",
+    "```\n",
     "\n",
     "### Adding software to your environment using the `module` Command\n",
     "\n",
@@ -135,7 +144,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.12.7"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
I am a bit unclear about the  use of `example.bashrc`.  

- why not just provide a patch, rather than copy the whole thing? e.g. `tutorials/Julia_ECCO_and_more/setup_modules.csh` and diff below. This would avoid overwriting `.bashrc`, which seems a bit hazardous.
- did you mean to point to (a) `/home/owang/.local/bin` or the user's (b) `$HOME/.local/bin`? In the PR, there is a possible alternative (commented out) that would switch from (a) to (b). But maybe the tutorials require something specific from (a)?

_The difference from the default `.bashrc` is shown below._

```
119,120c119
< # initiate SPACK profile
< source /shared/spack/share/spack/setup-env.sh

122,127c121
< # load compiler, MPI, and netCDF modules
< module load intel-oneapi-compilers-2021.2.0-gcc-11.1.0-adt4bgf
< module load intel-oneapi-mpi-2021.2.0-gcc-11.1.0-ibxno3u
< module load netcdf-c-4.8.1-gcc-11.1.0-6so76nc
< module load netcdf-fortran-4.5.3-gcc-11.1.0-d35hzyr
< module load hdf5-1.10.7-gcc-9.4.0-vif4ht3

129,132c123,125
< # 2024-09-11 The following changes needed for the EMU tool.
< # load module for singularity
< module load singularity-3.8.3-gcc-11.1.0-wqau5pb
< module load python-3.9.7-gcc-11.1.0-cacmhhm

134,135c127,130
< # add new path
< export PATH="$PATH:/home/owang/.local/bin"
```